### PR TITLE
[DS-3361] improve the Git checkout, added exec to add GitHub fingerprint

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -82,6 +82,9 @@ define dspace::install ($owner             = $dspace::owner,
 
 ->
     # ensure the GitHub SSH host authenticity is handled before we check out anything
+    # can return either 0 or 1, both are OK
+    # return 1 = warning about adding the fingerprint is thrown, this is a good thing, we want this
+    # return 0 = everything worked fine, the fingerprint is already configured
     exec { "Adding the fingerprint for GitHub so we can connect to it":
         command   => "ssh -T -oStrictHostKeyChecking=no git@github.com",
         returns   => [0,1],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -81,9 +81,18 @@ define dspace::install ($owner             = $dspace::owner,
     }
 
 ->
+    # ensure the GitHub SSH host authenticity is handled before we check out anything
+    exec { "Adding the fingerprint for GitHub so we can connect to it":
+        command   => "ssh -T -oStrictHostKeyChecking=no git@github.com",
+        returns   => [0,1],
+        user      => $owner,
+        logoutput => true,
+    }
+
+->
 
     exec { "Cloning DSpace source code into ${src_dir}":
-        command   => "git init && git remote add origin ${git_repo} && git fetch --all && git checkout master",
+        command   => "git init && git remote add origin ${git_repo} && git fetch --all && git checkout -B master origin/master",
         creates   => "${src_dir}/.git",
         user      => $owner,
         cwd       => $src_dir, # run command from this directory


### PR DESCRIPTION
The Git checkout can sometimes fail to actually check out the specified branch, I've slightly modified the checkout command to make it sturdier. I've also added an exec to ensure that the Github.com fingerprint is added for the user who is cloning from GitHub, to ensure the specified user can sucessfully clone from GitHub.com.
